### PR TITLE
Añade en router y controller la petición de partidas por número de letras. También protege ambas peticiones de partidas get, obligando a pedir un token.

### DIFF
--- a/backend/controllers/partidasController.ts
+++ b/backend/controllers/partidasController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import { Partida } from "../models/partida";
+import { Op, where } from "sequelize";
 
 export const getPartidas = async (req: Request, res: Response) => {
 	try {
@@ -28,6 +29,22 @@ export const insertPartida = async (req: Request, res: Response) => {
 		console.log(error);
 		res.status(500).json({
 			msg: "Hable con el administrador",
+		});
+	}
+};
+export const getPartidasPorLetras = async (req: Request, res: Response) => {
+	const { letras } = req.params;
+	try {
+		const partidas = await Partida.findAll({
+			where: {
+				numeroLetras: parseInt(letras),
+			},
+		});
+		res.status(200).json(partidas);
+	} catch (error) {
+		console.log(error);
+		res.status(500).json({
+			msg: "Se ha producido un error al mostrar las partidas",
 		});
 	}
 };

--- a/backend/routes/routerPartidas.ts
+++ b/backend/routes/routerPartidas.ts
@@ -1,7 +1,11 @@
 import { Router } from "express";
 import { check } from "express-validator";
 import { validarCampos } from "../middlewares/validarCampos";
-import { getPartidas, insertPartida } from "../controllers/partidasController";
+import {
+	getPartidas,
+	getPartidasPorLetras,
+	insertPartida,
+} from "../controllers/partidasController";
 import {
 	numeroLetrasValidoPartida,
 	partidaExiste,
@@ -9,8 +13,19 @@ import {
 import { validarJWT } from "../middlewares/validarJWT";
 
 export const routerPartidas = Router();
+routerPartidas.get("/", [validarJWT, validarCampos], getPartidas);
 
-routerPartidas.get("/", getPartidas);
+routerPartidas.get(
+	"/:letras",
+	[
+		validarJWT,
+		check("letras", "El número de letras es obligatorio").not().isEmpty(),
+		check("letras", "El número de letras debe de ser numérico").isInt(),
+		check("letras").custom(numeroLetrasValidoPartida),
+		validarCampos,
+	],
+	getPartidasPorLetras
+);
 
 routerPartidas.post(
 	"/",


### PR DESCRIPTION
Lo dicho en el asunto, con el fin de poder listar las partidas organizadas por número de letras, así el jugador puede decidir a cuál gujar.